### PR TITLE
Implementing -A "not draw axes" feature from Guff

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -11,6 +11,7 @@ pub(crate) struct Opt {
     pub(crate) height: usize,
     pub(crate) mode: Mode,
     pub(crate) cdf: bool,
+    pub(crate) draw_axes: bool,
 }
 
 impl Opt {
@@ -23,6 +24,7 @@ impl Opt {
             height: 40,
             mode: Mode::Dot,
             cdf: false,
+            draw_axes: true,
         };
         let mut parser = lexopt::Parser::from_env();
         while let Some(arg) = parser.next().context("read next argument")? {
@@ -71,6 +73,9 @@ impl Opt {
                 }
                 Long("cdf") => {
                     opt.cdf = true;
+                }
+                Short('A') => {
+                    opt.draw_axes = false;
                 }
                 arg => return Err(arg.unexpected().into()),
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ fn main() -> eyre::Result<()> {
         height,
         mode,
         cdf,
+        draw_axes,
     } = Opt::parse_from_env().context("parse command-line arguments")?;
 
     let mut data = Data::default();
@@ -151,7 +152,10 @@ fn main() -> eyre::Result<()> {
         frame = Frame::new_over(width, height, &data);
     }
 
-    frame.draw_into(&mut canvas);
+    //if -A option, we don't draw axes.
+    if draw_axes {
+        frame.draw_into(&mut canvas);
+    }
     data.draw_into(&mut canvas, &frame);
 
     let stdout = std::io::stdout();


### PR DESCRIPTION
In response to TODOs list, this PR adds a `draw_axes` field to the Opt struct (default to true) and an `-A` option to the parser to set it to false. In `main.rs`, if the flag is set to false, we don't call `frame.draw_into` function.

### Some examples:
```
echo -e 2\n3|cargo run
echo -e 2\n3|cargo run -- -A
```
![Screenshot_2025-06-17_07-29-17](https://github.com/user-attachments/assets/4fb79d43-b83e-4c36-aaed-fa940f601f65)


```
echo -e -3 -3\n-2 -2\n-1 -1\n0 0\n1 1\n2 2\n3 3|cargo run -- -x
echo -e -3 -3\n-2 -2\n-1 -1\n0 0\n1 1\n2 2\n3 3|cargo run -- -x -A
```
![Screenshot_2025-06-17_07-30-24](https://github.com/user-attachments/assets/bc9338cd-ed45-40c4-8a59-6721c78f0a92)

In dings directory:
```
fd -tf |xargs wc -l|awk '{print($1)}'|cargo run
fd -tf |xargs wc -l|awk '{print($1)}'|cargo run -- -A
```
![Screenshot_2025-06-17_07-31-15](https://github.com/user-attachments/assets/250e1943-59d3-4924-b4bf-8f20ad679bd6)