### PR TITLE
Implementing -f to flip X and Y

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -12,6 +12,7 @@ pub(crate) struct Opt {
     pub(crate) mode: Mode,
     pub(crate) cdf: bool,
     pub(crate) draw_axes: bool,
+    pub(crate) flip: bool,
 }
 
 impl Opt {
@@ -25,6 +26,7 @@ impl Opt {
             mode: Mode::Dot,
             cdf: false,
             draw_axes: true,
+            flip: false,
         };
         let mut parser = lexopt::Parser::from_env();
         while let Some(arg) = parser.next().context("read next argument")? {
@@ -70,6 +72,9 @@ impl Opt {
                 }
                 Short('x') => {
                     opt.x_is_row = false;
+                }
+                Short('f') => {
+                    opt.flip = true;
                 }
                 Long("cdf") => {
                     opt.cdf = true;

--- a/src/data.rs
+++ b/src/data.rs
@@ -13,6 +13,11 @@ impl Data {
         for (row, x) in self.xs.iter().copied().enumerate() {
             let x_cell = using.x_to_column(x);
 
+            //in the flip case, we can have x Nan values
+            if !x.is_finite() {
+                continue;
+            }
+
             for (column, ys) in self.ys.iter().enumerate() {
                 let y = ys[row];
 


### PR DESCRIPTION
Hi Jon,
sorry for the mess with this PR 😑. I can't reopen the [old one](https://github.com/jonhoo/dings/pull/5).
Two weeks ago, you said:

> Reading through the diff now, I wonder if it wouldn't be easier to simply swap x and y when reading the data in, and let all the plotting logic remain the same? What do you think?

So I restarted from main and did the flip before any plotting code is triggered. I obtain the same results as before.

I think we need to start writing tests to validate this PR. But for that, we need to split the code of `fn main` into different functions. To start, maybe a function that returns xs and ys Vec? With tests for normal case, -x and -f flags and particular inputs like no data, different numbers of columns between lines etc. Tell me how you would like this to be organized and I will work on it.